### PR TITLE
仮プログラムを修正

### DIFF
--- a/docs/program/index.html
+++ b/docs/program/index.html
@@ -38,7 +38,7 @@
   <li>本語評価用データセットの構築と公開（１）</li>
   <ul>
     <li>座長: 河原大輔</li>
-    <li class="talk">JGLUE: 日本語における言語理解ベンチマークの構築（柴田知秀・栗原健太郎・河原大輔）</li>
+    <li class="talk">JGLUE: 日本語言語理解ベンチマーク（柴田知秀・栗原健太郎・河原大輔）</li>
     <li class="talk">日本語版CoLAの構築の舞台裏（染谷大河・大関洋平）</li>
     <li class="talk">QAにおける評価用データセットの役割と日本語QAデータセットの必要性についての考察（田保健士郎・小林景）</li>
     <li class="lt">A Japanese Temporal Commonsense Reasoning Dataset (Lis Pereira)</li>

--- a/src/program.md
+++ b/src/program.md
@@ -18,7 +18,7 @@ description: "言語処理学会第28回年次大会 併設ワークショップ
   <li>本語評価用データセットの構築と公開（１）</li>
   <ul>
     <li>座長: 河原大輔</li>
-    <li class="talk">JGLUE: 日本語における言語理解ベンチマークの構築（柴田知秀・栗原健太郎・河原大輔）</li>
+    <li class="talk">JGLUE: 日本語言語理解ベンチマーク（柴田知秀・栗原健太郎・河原大輔）</li>
     <li class="talk">日本語版CoLAの構築の舞台裏（染谷大河・大関洋平）</li>
     <li class="talk">QAにおける評価用データセットの役割と日本語QAデータセットの必要性についての考察（田保健士郎・小林景）</li>
     <li class="lt">A Japanese Temporal Commonsense Reasoning Dataset (Lis Pereira)</li>


### PR DESCRIPTION
[JED2022 仮プログラム | NLP2022 Workshop on Japanese Evaluation Dataset](http://localhost:8080/jed2022/program/)

- [x] `アスペクト感情分析（亀谷聡）` => `学習データセット改善によるアスペクト感情分析モデルの性能改善（亀谷聡）`
- [x] `供述調書に現れる数量表現の推論テストセットの構築（小谷野）` => `供述調書に現れる数量表現の推論テストセットの構築（小谷野華那・谷中瞳・峯島宏次・福田浩司・橋爪宏典・戸次大介）`
- [x] `JGLUE: 日本語における言語理解ベンチマークの構築（柴田知秀・栗原健太郎・河原大輔）` => `JGLUE: 日本語言語理解ベンチマーク（柴田知秀・栗原健太郎・河原大輔）`